### PR TITLE
android7.0以上分屏/多窗口时，解决键盘与面板切换监听失效的bug

### DIFF
--- a/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedActivity.java
+++ b/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedActivity.java
@@ -198,4 +198,11 @@ public class ChattingResolvedActivity extends AppCompatActivity {
         return super.dispatchKeyEvent(event);
     }
 
+    // 当屏幕分屏/多窗口变化时回调
+    @Override
+    public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
+        super.onMultiWindowModeChanged(isInMultiWindowMode);
+        KPSwitchConflictUtil.onMultiWindowModeChanged(isInMultiWindowMode);
+    }
+
 }

--- a/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedFragmentActivity.java
+++ b/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedFragmentActivity.java
@@ -152,4 +152,10 @@ public class ChattingResolvedFragmentActivity extends FragmentActivity {
         return super.dispatchKeyEvent(event);
     }
 
+    // 当屏幕分屏/多窗口变化时回调
+    @Override
+    public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
+        super.onMultiWindowModeChanged(isInMultiWindowMode);
+        KPSwitchConflictUtil.onMultiWindowModeChanged(isInMultiWindowMode);
+    }
 }

--- a/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedHandleByPlaceholderActivity.java
+++ b/app/src/main/java/cn/dreamtobe/kpswitch/demo/activity/ChattingResolvedHandleByPlaceholderActivity.java
@@ -122,4 +122,11 @@ public class ChattingResolvedHandleByPlaceholderActivity extends AppCompatActivi
         }
         return super.dispatchKeyEvent(event);
     }
+
+    // 当屏幕分屏/多窗口变化时回调
+    @Override
+    public void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
+        super.onMultiWindowModeChanged(isInMultiWindowMode);
+        KPSwitchConflictUtil.onMultiWindowModeChanged(isInMultiWindowMode);
+    }
 }

--- a/library/src/main/java/cn/dreamtobe/kpswitch/util/KPSwitchConflictUtil.java
+++ b/library/src/main/java/cn/dreamtobe/kpswitch/util/KPSwitchConflictUtil.java
@@ -41,6 +41,9 @@ import cn.dreamtobe.kpswitch.handler.KPSwitchRootLayoutHandler;
  */
 public class KPSwitchConflictUtil {
 
+    // whether current activity is in multi window mode
+    private static boolean mIsInMultiWindowMode = false;
+
     /**
      * @see #attach(View, View, View, SwitchClickListener)
      */
@@ -202,6 +205,8 @@ public class KPSwitchConflictUtil {
         KeyboardUtil.showKeyboard(focusView);
         if (isHandleByPlaceholder(activity)) {
             panelLayout.setVisibility(View.INVISIBLE);
+        } else if (mIsInMultiWindowMode) {
+            panelLayout.setVisibility(View.GONE);
         }
     }
 
@@ -335,4 +340,9 @@ public class KPSwitchConflictUtil {
         }
         boundTriggerSubPanelView.setVisibility(View.VISIBLE);
     }
+
+    public static void onMultiWindowModeChanged(boolean isInMultiWindowMode) {
+        mIsInMultiWindowMode = isInMultiWindowMode;
+    }
+
 }


### PR DESCRIPTION
分屏/多窗口时，OnGlobalLayoutListener监听键盘的展开或收起会失效。这时候应该在点击按钮时直接隐藏面板。